### PR TITLE
Add support for UserMenuHeaderComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v6.3.0 (Not Published Yet)
+
+### Added
+
+-  Added theme support for `UserMenuHeaderComponent`. 
+
 ## v6.2.1 (August 30, 2021)
 
 ### Fixed

--- a/_pxb-component-theme.scss
+++ b/_pxb-component-theme.scss
@@ -135,7 +135,9 @@
     }
     .pxb-user-menu-overlay,
     .pxb-user-menu-bottomsheet {
-        .pxb-drawer-header-content.mat-toolbar-single-row.mat-toolbar {
+        .pxb-drawer-header-content.mat-toolbar-single-row.mat-toolbar,
+        .pxb-user-menu-header-content.mat-toolbar-single-row.mat-toolbar,
+        {
             background-color: unset;
             color: unset;
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/angular-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.2.1",
+    "version": "6.3.0-beta.0",
     "description": "Angular themes for PX Blue applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Adds support for a new UserMenuHeaderComponent, used inside a `<pxb-user-menu>`. 
- Non-breaking change.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![user-menu-theme](https://user-images.githubusercontent.com/6538289/134099326-3bf12068-1ddf-490c-8bd1-b47718ab8242.gif)


