### PR TITLE
Make highlight color red for invalid fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--  Added theme support for `<pxb-user-menu>`'s header. 
+-  Added theme support for `UserMenuHeaderComponent`. 
 -  Red text highlight color for invalid form fields.
 
 ## v6.2.1 (August 30, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
--  Added theme support for `UserMenuHeaderComponent`. 
+-  Added theme support for `<pxb-user-menu>`'s header. 
+-  Red text highlight color for invalid form fields.
 
 ## v6.2.1 (August 30, 2021)
 

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -38,6 +38,7 @@
         placeholder: map-get($pxb-black, 100),
         hint: map-get($warn, 500),
         filledBackgroundColor: map-get($pxb-white, 200),
+        highlightColor: rgba(map-get($warn, 500), 0.2),
         label: (
             withoutValue: map-get($warn, 500),
             withValue: map-get($warn, 500),

--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -167,6 +167,7 @@
         placeholder: map-get($foreground, disabled),
         hint: map-get($warn, 200),
         filledBackgroundColor: rgba(255, 255, 255, 0.1),
+        highlightColor: rgba(map-get($warn, 500), 0.5),
         label: (
             withoutValue: map-get($warn, 200),
             withValue: map-get($warn, 200),

--- a/mixins/input-field.scss
+++ b/mixins/input-field.scss
@@ -97,6 +97,16 @@
             color: map-get($palette, hint);
         }
 
+        /* User Input Text */
+        &.mat-form-field-invalid {
+            .mat-input-element::selection {
+                background-color: map-get($palette, highlightColor);
+            }
+            .mat-input-element::-moz-selection {
+                background-color: map-get($palette, highlightColor);
+            }
+        }
+
         /* Standard / Legacy Variant */
         &.mat-form-field-appearance-legacy,
         &.mat-form-field-appearance-standard,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/angular-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.3.0-beta.0",
+    "version": "6.3.0-beta.1",
     "description": "Angular themes for PX Blue applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Partially addresses https://github.com/pxblue/angular-design-patterns/issues/119

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
## Changes proposed in this Pull Request
- Make light theme input highlight color red500, 0.2
- Make dark theme input highlight color red500, 0.5

<!-- Include screenshots if they will help illustrate the changes in this PR -->
## Screenshots
When the user input text is selected,
### Light
![image](https://user-images.githubusercontent.com/8997218/134229995-d1d89918-1443-4c05-b0d3-3c2c13bcf13f.png)
![image](https://user-images.githubusercontent.com/8997218/134230012-5b2735e2-b611-4ac5-bbcf-1651fbec240b.png)
![image](https://user-images.githubusercontent.com/8997218/134230055-28b2a4a6-e3da-446c-8210-a3b701f0c39a.png)
For fields without any warnings, they are still all good (browser default)
![image](https://user-images.githubusercontent.com/8997218/134230404-ca00cc35-0171-4fe7-8f87-f7d56b8c10ad.png)


### Dark
![image](https://user-images.githubusercontent.com/8997218/134230219-b72b864e-8a7b-4940-920b-6cd0d5267b77.png)
![image](https://user-images.githubusercontent.com/8997218/134230255-f15a0ab6-d290-4a6b-b341-32cb459a664d.png)
![image](https://user-images.githubusercontent.com/8997218/134230292-b2026d9b-d539-4cfa-87ae-0e9fc97ea5c7.png)
For fields without any warnings, they are still all good (browser default)
![image](https://user-images.githubusercontent.com/8997218/134230353-5632a2f6-86cf-426e-b9d4-fd879b3cc902.png)

