### PR TITLE
Bug/20 button height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Added
 
--  Added theme support for `UserMenuHeaderComponent`. 
+-  Added theme support for `UserMenuHeaderComponent`.
+
+
+### Changed
+
+-  Changed `<mat-button-toggle-group>` default height to 36px.
 
 ## v6.2.1 (August 30, 2021)
 

--- a/_common.scss
+++ b/_common.scss
@@ -13,4 +13,8 @@
     .mat-chip .mat-chip-avatar {
         font-size: 0.625rem;
     }
+
+    .mat-button-toggle .mat-button-toggle-label-content {
+        line-height: 36px;
+    }
 }

--- a/_common.scss
+++ b/_common.scss
@@ -14,7 +14,17 @@
         font-size: 0.625rem;
     }
 
-    .mat-button-toggle .mat-button-toggle-label-content {
-        line-height: 36px;
+    .mat-button-toggle-group {
+        height: 36px;
+        box-sizing: border-box;
+        .mat-button-toggle-button {
+            height: 100%;
+        }
+        .mat-button-toggle {
+            height: 100%;
+            .mat-button-toggle-label-content {
+                line-height: 100%;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #20 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- MatButtonToggleGroup is now 36px height. 
