### PR TITLE
Bug/22 drawer light theme active icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 ### Added
 
--  Added theme support for `UserMenuHeaderComponent`. 
+-   Added theme support for `UserMenuHeaderComponent`.
+
+### Fixed
+
+-   Fixed light theme active item icon color for `<pxb-drawer>`.
 
 ## v6.2.1 (August 30, 2021)
 
 ### Fixed
 
--  Fixed bug in `<mat-chip>` styles where non-selected chips appeared as selected. 
+-   Fixed bug in `<mat-chip>` styles where non-selected chips appeared as selected.
 
 ## v6.2.0 (August 25, 2021)
 

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -431,9 +431,11 @@
     /* PXB Drawer */
     .pxb-drawer {
         background-color: map-get($pxb-white, 50);
+
         .pxb-drawer-nested-nav-item .mat-expansion-panel {
             background-color: map-get($pxb-white, 200);
         }
+
         .pxb-drawer-nav-item-active-highlight {
             opacity: 0.05;
         }
@@ -443,7 +445,8 @@
         .pxb-drawer-nav-item-active .pxb-info-list-item .pxb-info-list-item-icon-wrapper {
             color: map-get($primary, 500);
         }
-        .pxb-info-list-item .mat-list-item-content .mat-list-icon {
+
+        .pxb-info-list-item .mat-list-item-content {
             color: map-get($foreground, text);
         }
     }

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -446,7 +446,7 @@
             color: map-get($primary, 500);
         }
 
-        .pxb-info-list-item .mat-list-item-content {
+        .pxb-info-list-item .pxb-info-list-item-icon-wrapper  {
             color: map-get($foreground, text);
         }
     }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #22 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Light theme Drawer Nav Item Active Color should be blue[500] 
- Light theme Drawer Nav Item Inactive Text & Icon color should be black[500]


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Deployed here: https://pxb-angular-theme-demo.web.app/
