### PR TITLE
fixed slider disable color for blui and dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## v6.3.1 (Not yet published)
 
 ### Fixed
-
--   Fixed default active item background color in `<mat-select-panel>`.
 -   Fixed disabled slider color in `<mat-slider>`.
 
 ## v6.3.0 (November 3, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Fixed
 
 -   Fixed default active item background color in `<mat-select-panel>`.
--   
+-   Fixed disabled slider color in `<mat-slider>`.
+
 ## v6.3.0 (November 3, 2021)
 
 ### Changed

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -424,7 +424,7 @@
             }
 
             .mat-slider-track-fill {
-                background-color: map-get($pxb-gray, 300);
+                background-color: map-get($blui-gray, 300);
             }
         }
     }

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -422,6 +422,10 @@
             .mat-slider-thumb {
                 background-color: map-get($foreground, disabled);
             }
+
+            .mat-slider-track-fill {
+                background-color: map-get($pxb-gray, 300);
+            }
         }
     }
     .mat-slider-horizontal .mat-slider-track-background,

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -471,11 +471,11 @@
     }
 
     /* mat-select panel  */
-    .mat-option.mat-active {
-        background-color: rgba(map-get($blui-black, 500), .05);
-    }
+    // .mat-option.mat-active {
+    //     background-color: rgba(map-get($blui-black, 500), .05);
+    // }
     
-    .mat-select-panel .mat-option.mat-selected:not(.mat-option-multiple) {
-        background-color: rgba(map-get($blui-black, 500), .05);
-    }
+    // .mat-select-panel .mat-option.mat-selected:not(.mat-option-multiple) {
+    //     background-color: rgba(map-get($blui-black, 500), .05);
+    // }
 }

--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -465,6 +465,10 @@
             .mat-slider-thumb {
                 background-color: map-get($foreground, disabled);
             }
+
+            .mat-slider-track-fill {
+                background-color: map-get($pxb-gray, 500);
+            }
         }
     }
     .mat-slider-horizontal .mat-slider-track-background,

--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -467,7 +467,7 @@
             }
 
             .mat-slider-track-fill {
-                background-color: map-get($pxb-gray, 500);
+                background-color: map-get($blui-gray, 500);
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.3.1",
+    "version": "6.3.1-beta.0",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [27](https://github.com/pxblue/angular-themes/issues/27) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- gray-300 for disabled slider in blui-theme.
-  gray-500 for disabled slider in dark-theme.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Primary theme:

<img width="919" alt="Screenshot 2021-12-07 at 6 12 11 PM" src="https://user-images.githubusercontent.com/10433274/145032552-e2c6146f-140b-4b4e-8870-8d8a5a4d153d.png">

Dark Theme:

<img width="923" alt="Screenshot 2021-12-07 at 6 12 22 PM" src="https://user-images.githubusercontent.com/10433274/145032623-19ef2506-30eb-4896-b811-c7b7e4cbe08f.png">

